### PR TITLE
AMM-2228 allow multiple diagnosis search in doctor module

### DIFF
--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/general-opd-diagnosis/general-opd-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/general-opd-diagnosis/general-opd-diagnosis.component.ts
@@ -259,7 +259,7 @@ export class GeneralOpdDiagnosisComponent
   onDiagnosisInputKeyup(value: string, index: number) {
     if (value.length >= 3) {
       this.masterdataService
-        .searchDiagnosisBasedOnPageNo(value, index)
+        .searchDiagnosisBasedOnPageNo(value, 0)
         .subscribe((results: any) => {
           this.suggestedDiagnosisList[index] = results?.data?.sctMaster;
         });

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-care-diagnosis/ncd-care-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-care-diagnosis/ncd-care-diagnosis.component.ts
@@ -274,7 +274,7 @@ export class NcdCareDiagnosisComponent implements OnInit, DoCheck {
   onDiagnosisInputKeyup(value: string, index: number) {
     if (value.length >= 3) {
       this.masterdataService
-        .searchDiagnosisBasedOnPageNo(value, index)
+        .searchDiagnosisBasedOnPageNo(value, 0)
         .subscribe((results: any) => {
           this.suggestedDiagnosisList[index] = results?.data?.sctMaster;
         });

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-screening-diagnosis/ncd-screening-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/ncd-screening-diagnosis/ncd-screening-diagnosis.component.ts
@@ -330,7 +330,7 @@ export class NcdScreeningDiagnosisComponent
    onDiagnosisInputKeyup(value: string, index: number) {
     if (value.length >= 3) {
       this.masterdataService
-        .searchDiagnosisBasedOnPageNo(value, index)
+        .searchDiagnosisBasedOnPageNo(value, 0)
         .subscribe((results: any) => {
           this.suggestedDiagnosisList[index] = results?.data?.sctMaster;
         });

--- a/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/pnc-diagnosis/pnc-diagnosis.component.ts
+++ b/src/app/app-modules/nurse-doctor/case-record/general-case-record/diagnosis/pnc-diagnosis/pnc-diagnosis.component.ts
@@ -434,7 +434,7 @@ export class PncDiagnosisComponent
   onDiagnosisInputKeyup(value: string, index: number) {
     if (value.length >= 3) {
       this.masterdataService
-        .searchDiagnosisBasedOnPageNo(value, index)
+        .searchDiagnosisBasedOnPageNo(value, 0)
         .subscribe((results: any) => {
           this.suggestedDiagnosisList[index] = results?.data?.sctMaster;
         });

--- a/src/app/app-modules/registrar/registration/registration.component.ts
+++ b/src/app/app-modules/registrar/registration/registration.component.ts
@@ -756,17 +756,19 @@ export class RegistrationComponent
    */
   postButtonCall() {
     if (this.isSubmitting) return;
+    this.isSubmitting = true;
     const valid = this.checkValids(this.beneficiaryRegistrationForm);
 
     // Need to revert back the health id change - 2024
     // if (valid && this.checkValidHealthID(null)) {
     if (valid) {
-      this.isSubmitting = true;
       if (this.patientRevisit) {
         this.updateBeneficiarynPassToNurse();
       } else if (!this.patientRevisit) {
         this.submitBeneficiaryDetails();
       }
+    } else {
+      this.isSubmitting = false;
     }
   }
   checkValidHealthID(type: any) {


### PR DESCRIPTION
## 📋 Description

JIRA ID: 

AMM-2228
---

## ✅ Type of Change

- [ ] 🐞 **Bug fix** (non-breaking change which resolves an issue)
- [ ] ✨ **New feature** (non-breaking change which adds functionality)
- [ ] 🔥 **Breaking change** (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🛠 **Refactor** (change that is neither a fix nor a new feature)
- [ ] ⚙️ **Config change** (configuration file or build script updates)
- [ ] 📚 **Documentation** (updates to docs or readme)
- [ ] 🧪 **Tests** (adding new or updating existing tests)
- [ ] 🎨 **UI/UX** (changes that affect the user interface)
- [ ] 🚀 **Performance** (improves performance)
- [ ] 🧹 **Chore** (miscellaneous changes that don't modify src or test files)

---

## ℹ️ Additional Information

 - Row index was incorrectly passed as pageNo to searchDiagnosisBasedOnPageNo(),
  causing empty results when searching for 2nd+ diagnoses
  - Fixed in all 4 diagnosis components: General OPD, PNC, NCD Care, NCD Screening
  - Also includes Common-UI submodule update for AMM-2217 duplicate submit fix
